### PR TITLE
Improve landing page in Japanese

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Legendaly</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; background-color: #f0f0f0; }
+    header { margin-top: 40px; }
+    img.logo { width: 300px; }
+    img.shot { width: 600px; border: 1px solid #ccc; margin-top: 20px; }
+    section { max-width: 700px; margin: 40px auto; padding: 0 20px; }
+  </style>
+</head>
+<body>
+  <header>
+    <img src="logo.svg" alt="Legendalyのロゴ" class="logo" />
+  </header>
+  <section>
+    <p>Legendaly は OpenAI を利用して短い名言を生成する CLI ツールです。</p>
+    <p>以下はツール実行時の例です。</p>
+    <img src="screenshot.svg" alt="Legendaly 実行例" class="shot" />
+    <h2>使い方</h2>
+    <ol style="text-align: left;">
+      <li>リポジトリをクローンします。</li>
+      <li><code>npm install</code> を実行します。</li>
+      <li><code>node legendaly.js</code> で起動します。</li>
+    </ol>
+    <p>オプションとして <code>TONE</code> や <code>TWEET_USER</code> を環境変数で指定可能です。</p>
+  </section>
+  <footer>
+    <p><a href="https://github.com/yourname/legendaly">GitHub レポジトリ</a></p>
+  </footer>
+</body>
+</html>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="80" viewBox="0 0 300 80">
+  <rect width="300" height="80" fill="black"/>
+  <text x="150" y="55" font-family="Verdana" font-size="40" fill="white" text-anchor="middle">Legendaly</text>
+</svg>

--- a/docs/screenshot.svg
+++ b/docs/screenshot.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200" viewBox="0 0 600 200">
+  <rect width="600" height="200" fill="black"/>
+  <text x="300" y="50" font-family="monospace" font-size="24" fill="cyan" text-anchor="middle">Legendaly</text>
+  <text x="300" y="80" font-family="monospace" font-size="16" fill="white" text-anchor="middle">AIで名言を創作中...</text>
+  <text x="50" y="130" font-family="monospace" font-size="14" fill="white">--- 「自らの運命を受け入れよ」</text>
+  <text x="420" y="160" font-family="monospace" font-size="14" fill="white">2024-01-01 Unsung Hero</text>
+</svg>


### PR DESCRIPTION
## Summary
- refine docs landing page for Japanese audience
- tweak screenshot text to Japanese

## Testing
- `npm test` *(fails: Missing script)*