### PR TITLE
Add OPENAI_CLIENT_PATH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ It types out beautiful quotes like a sage, then fades them into mist, one by one
 npm install
 ```
 
-You also need an OpenAI API key. The script expects a helper at
-`~/.config/common/openaiClients.js` that provides a configured OpenAI client.
-Create this file (or modify `legendaly.js` to point to your own helper) and set
-up your credentials there. A typical helper uses `dotenv` to load a `.env` file.
+You also need an OpenAI API key. By default the program loads a helper module
+from `~/.config/common/openaiClients.js` that exports a configured OpenAI
+client.  If you keep this helper in another location, set the
+`OPENAI_CLIENT_PATH` environment variable to point to it.  A typical helper uses
+`dotenv` to load a `.env` file with your credentials.
 
 ## Usage
 
@@ -40,6 +41,7 @@ Create a `.env` file to customize behavior with the following environment variab
 - `FETCH_INTERVAL` – Seconds between displaying each quote (default: `3`)
 - `LANGUAGE` – Output language (default: `ja`)
   - Available languages: `ja` (Japanese), `en` (English), `zh` (Chinese), `ko` (Korean), `fr` (French), `es` (Spanish), `de` (German)
+- `OPENAI_CLIENT_PATH` – Path to the helper that exports a configured OpenAI client (default: `~/.config/common/openaiClients.js`)
 
 ### Visual Settings
 - `FIGLET_FONT` – ASCII art font used for the header (default: `slant`)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,6 +27,7 @@ Legendalyは多数の環境変数を通じて動作をカスタマイズでき�
 | `QUOTE_COUNT` | 起動時に取得する名言の数 | `100` |
 | `FETCH_INTERVAL` | 名言の表示間隔（秒） | `3` |
 | `LANGUAGE` | 出力言語 | `ja` |
+| `OPENAI_CLIENT_PATH` | OpenAIクライアントモジュールへのパス | `~/.config/common/openaiClients.js` |
 
 ### 表示設定
 
@@ -69,6 +70,11 @@ LANGUAGE=en node legendaly.js
 # フランス語でサイバーパンク調の名言
 LANGUAGE=fr TONE=cyberpunk node legendaly.js
 ```
+
+## OpenAIクライアント設定
+
+`OPENAI_CLIENT_PATH` 環境変数で使用する OpenAI クライアントモジュールのパスを変更できます。
+デフォルトは `~/.config/common/openaiClients.js` です。
 
 ## 表示フォント
 

--- a/legendaly.js
+++ b/legendaly.js
@@ -6,7 +6,9 @@ const fs = require('fs');
 const readline = require('readline');
 const { execSync } = require('child_process');
 require('dotenv').config();
-const openai = require(path.join(os.homedir(), '.config', 'common', 'openaiClients.js'));
+const openaiClientPath = process.env.OPENAI_CLIENT_PATH ||
+  path.join(os.homedir(), '.config', 'common', 'openaiClients.js');
+const openai = require(openaiClientPath);
 const isFullwidth = require('is-fullwidth-code-point').default;
 
 const tone = process.env.TONE || 'epic';


### PR DESCRIPTION
## Summary
- allow overriding OpenAI helper module path via `OPENAI_CLIENT_PATH`
- document the new environment variable in README and usage guide

## Testing
- `npm test` *(fails: Missing script)*